### PR TITLE
Fix in IlsErdingParser

### DIFF
--- a/Parsers/Library/IlsErdingParser.cs
+++ b/Parsers/Library/IlsErdingParser.cs
@@ -111,7 +111,8 @@ namespace AlarmWorkflow.Parser.Library
                 try
                 {
                     string line = lines[i];
-                    if (line.Length == 0)
+                    if (line.Length == 0
+                        || line.StartsWith("------- FAX"))
                     {
                         continue;
                     }


### PR DESCRIPTION
Das Alarmfax von Erding beinhaltet seit kurzem am Ende der Seite (oder
des Faxes?) ein `------- FAX ------ FAX ------ FAX ------ FAX ------ FAX
------ FAX -------`. Dadurch wird die Bemerkung falsch ausgelesen.
