### PR TITLE
Update FEZMuenchenLandParser; Meldebild für Feuermelder

### DIFF
--- a/Parsers/Library/FEZMuenchenLandParser.cs
+++ b/Parsers/Library/FEZMuenchenLandParser.cs
@@ -87,6 +87,10 @@ namespace AlarmWorkflow.Parser.Library
                         break;
                     case CurrentSection.CMitteiler:
                         operation.Messenger = ParserUtility.GetMessageText(line, keyword);
+                        if (operation.Messenger.Contains("Hauptmelder"))
+                        {
+                            operation.Picture = "Feuermelder";
+                        }
                         break;
                     case CurrentSection.DEinsatzort:
                         operation.Einsatzort.Location = ParserUtility.GetMessageText(line, keyword);
@@ -115,7 +119,10 @@ namespace AlarmWorkflow.Parser.Library
                         operation.OperationPlan = ParserUtility.GetMessageText(line, keyword);
                         break;
                     case CurrentSection.LMeldebild:
-                        operation.Picture = ParserUtility.GetMessageText(line, keyword);
+                        if (operation.Picture != "Feuermelder")
+                        {
+                            operation.Picture = ParserUtility.GetMessageText(line, keyword);
+                        }
                         break;
                     case CurrentSection.MHinweis:
                         operation.Comment = ParserUtility.GetMessageText(line, keyword);

--- a/ReleaseNotes/0.9.9.0.txt
+++ b/ReleaseNotes/0.9.9.0.txt
@@ -15,6 +15,7 @@ Bearbeitet
   * ILS Rosenheim: Koordinaten werden ausgelesen
   * ILS Straubing: Fahrzeuge & Geräte werden richtig ausgelesen
   * ILS Traunstein: Koordinaten werden ausgelesen
+  * FEZ Muenchen Land: Meldebild für Feuermelder hinzugefügt
 Hinzugefügt
   * Ils Bamberg Forchheim
   * Ils Ludwigsburg


### PR DESCRIPTION
Das Meldebild bleibt bei einem Feuermelder leer, d.h wenn im Mitteiler das Wort Hauptmelder vorkommt wird das Meldebild auf "Feuermelder" gesetzt.
